### PR TITLE
Fix `jax.config`, remove astropy import

### DIFF
--- a/nuance/__init__.py
+++ b/nuance/__init__.py
@@ -1,7 +1,8 @@
 import jax
-from jax.config import config
 
 DEVICES_COUNT = jax.device_count()
+
+config = jax.config
 config.update("jax_enable_x64", True)
 
 from nuance.combined import CombinedNuance

--- a/nuance/star.py
+++ b/nuance/star.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import astropy.units as u
 import numpy as np
 
 G = 2942.2062175044193

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
+astropy = "*"
 python = ">=3.9,<3.12"
 tinygp = "*"
 jax = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nuance"
-version = "0.6.0"
+version = "0.6.1"
 description = "Transit signals detection among correlated noises"
 authors = ["Lionel Garcia"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-astropy = "*"
 python = ">=3.9,<3.12"
 tinygp = "*"
 jax = "*"


### PR DESCRIPTION
Two small changes to ensure that nuance runs without errors after installation via `pip`.

- `from jax.config import config` raises an `ImportError` in the newest version of JAX (0.4.25). It turns out that importing the `jax.config` submodule via `import jax.config` is deprecated and referencing the config object via `jax.config` is encouraged. Thus, `config = jax.config` was added to `__init__.py`, so that `nuance.config` can still be used to access `jax.config` as was the case previously, although one could probably debate whether this is desirable conceptually.
- `star.py` imports `import astropy.units as u`, but astropy was not listed as a dependency in `pyproject.toml`.

Keep up the inspiring work!