### PR TITLE
Typo fix in tess_search.ipynb

### DIFF
--- a/docs/notebooks/tutorials/tess_search.ipynb
+++ b/docs/notebooks/tutorials/tess_search.ipynb
@@ -210,7 +210,7 @@
     "gp_mean = mu(gp_params)\n",
     "split_idxs = [\n",
     "    0,\n",
-    "    *np.flatnonzero(np.diff(time) > 10 / 60 / 24),\n",
+    "    *np.flatnonzero(np.diff(time_masked) > 10 / 60 / 24),\n",
     "    len(time),\n",
     "]\n",
     "\n",


### PR DESCRIPTION
Hi Lionel,

Thanks for this lovely tool!

This PR addresses what I think is a typo in the "tess_search" notebook from the docs: I think the idea of the relevant splitting trick is to plot successive chunks of the light curve with plt.plot so that the lines are not linearly joined.  For this to work, I think the time array here needs to be "time_masked", not "time".

Thanks again!
Luke