### PR TITLE
Update periodic search

### DIFF
--- a/nuance/periodic_search.py
+++ b/nuance/periodic_search.py
@@ -90,3 +90,11 @@ def _solve(period, fold_f):
     epoch_i, duration_i = np.unravel_index(np.argmax(lls), lls.shape)
     epoch = phase[epoch_i] * period
     return epoch, duration_i, period
+
+
+def main():
+    return
+
+
+if __name__ == '__main__':
+    main()

--- a/nuance/periodic_search.py
+++ b/nuance/periodic_search.py
@@ -62,11 +62,10 @@ def _fold_ll(epochs, lls, z, vz):
     f_dz2 = core.nearest_neighbors(epochs, vz)
 
     def _fold(times):
-        lls = np.array([f_ll(time) for time in times])
-        zs = np.array([f_z(time) for time in times])
-        vzs = np.array([f_dz2(time) for time in times])
+        lls = f_ll(times)
+        zs = f_z(times)
+        vzs = f_dz2(times)
 
-        P1 = np.sum(lls, 0)
         vZ = 1 / np.sum(1 / vzs, 0)
         Z = vZ * np.sum(zs / vzs, 0)
         P1 = np.sum(lls, 0)

--- a/nuance/periodic_search.py
+++ b/nuance/periodic_search.py
@@ -39,14 +39,14 @@ def periodic_search(epochs, durations, ls, snr_f, progress=True):
     def _progress(x, **kwargs):
         return tqdm(x, **kwargs) if progress else x
 
-    def function(periods):
+    def function(periods, processes=None, chunksize=500):
         snr = np.zeros(len(periods))
         params = np.zeros((len(periods), 3))
 
         ctx = mp.get_context('spawn')  # Can't use fork with jax.
-        with ctx.Pool() as pool:
+        with ctx.Pool(processes=processes) as pool:
             for p, (epoch, duration_i, period) in enumerate(
-                _progress(pool.starmap(_solve, [(period, fold_f) for period in periods]), total=len(periods))
+                _progress(pool.starmap(_solve, [(period, fold_f) for period in periods], chunksize=chunksize), total=len(periods))
             ):
                 Dj = durations[duration_i]
                 snr[p], params[p] = float(snr_f(epoch, Dj, period)), (epoch, Dj, period)

--- a/nuance/periodic_search.py
+++ b/nuance/periodic_search.py
@@ -58,7 +58,7 @@ def periodic_search(epochs, durations, ls, snr_f, progress=True):
                 params[i::processes, 2] = periods_chunk
 
         # Use jax.vmap to get the SNR at each period.
-        snr_vmap = jax.vmap(snr_f, in_axes=(0, 0, 0))
+        snr_vmap = jax.pmap(snr_f, in_axes=(0, 0, 0))
         for i in _progress(range(0, len(periods), batch_size), unit_scale=batch_size):
             imin = i
             imax = i + batch_size


### PR DESCRIPTION
When running the periodic search I repeatedly got the warning: "os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock." 

It never seemed to cause any actual issues, but fork is set to be [deprecated](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) so I modified the periodic search to use 'spawn' instead. Since 'spawn' (and 'forkserver') don't allow the use of [global fold_f](https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods) I had to switch to `Pool.starmap` and explicitly pass fold_f.

While I was at it I also exposed `processes` and `chunksize` to allow the user more fine-grained control over the multiprocessing and added` if __name__ ==  '__main__':` which I understand to be good practice for multiprocessed code.

As a final note I wonder if it might be a good idea to move the snr_f evaluations outside of the `with Pool` statement ?