### PR TITLE
Fixes the bounds in bounded minimization.

### DIFF
--- a/nuance/utils.py
+++ b/nuance/utils.py
@@ -192,7 +192,7 @@ def bounded_minimize(fun, init_params, param_names=None, bounds_min=None, bounds
     bounds_min = {k: bounds_min.get(k, -jnp.inf) for k in param_names}
     bounds_max = {k: bounds_max.get(k, jnp.inf) for k in param_names}
 
-    bounds = (list(bounds_min.values()), list(bounds_max.values()))
+    bounds = (bounds_min, bounds_max)
 
     solver = jaxopt.ScipyBoundedMinimize(fun=inner)
     soln = solver.run(start, bounds)


### PR DESCRIPTION
It turns out there was no need to provide the bounds as a tuple of lists. In fact, doing so can cause the bounds to be applied to the wrong variables.