### PR TITLE
Fix flare masking in tess_search.ipynb

### DIFF
--- a/docs/notebooks/tutorials/tess_search.ipynb
+++ b/docs/notebooks/tutorials/tess_search.ipynb
@@ -163,13 +163,16 @@
     "\n",
     "flare_mask = np.ones_like(time).astype(bool)\n",
     "\n",
-    "for _ in range(3):\n",
-    "    residuals = flux - mu(gp_params)\n",
-    "    flare_mask = flare_mask & sigma_clip_mask(residuals, sigma=4.0, window=20)\n",
-    "    gp_params = minimize(nll, gp_params)\n",
+    "residuals = flux - mu(gp_params)\n",
     "\n",
-    "time_masked = time[flare_mask]\n",
-    "flux_masked = flux[flare_mask]"
+    "for _ in range(3):\n",
+    "    new_mask = sigma_clip_mask(residuals, sigma=5.0, window=5)\n",
+    "    flare_mask[flare_mask] &= new_mask\n",
+    "    time_masked = time[flare_mask]\n",
+    "    flux_masked = flux[flare_mask]\n",
+    "    mu, nll = gp_model(time_masked, flux_masked, build_gp)\n",
+    "    gp_params = minimize(nll, gp_params)\n",
+    "    residuals = flux_masked - mu(gp_params)"
    ]
   },
   {
@@ -450,7 +453,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nuance",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -464,10 +467,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  },
-  "orig_nbformat": 4
+   "version": "3.12.2"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The flare masking in the TESS tutorial was not actually implementing the iterative masking. I have changed it so that each time the new mask is calculated the time and flux arrays are masked, gp_model is regenerated with the new arrays, gp_params is reminimized, and new residuals are calculated. Note that the output is stale. I cannot actually run this notebook in this state on Macbook and it would require extensive changes, so I left the output untouched.